### PR TITLE
Add shortcuts to generate (g) and load (l) commands

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,9 +8,11 @@ module.exports = () => {
 
   switch (cmd) {
     case 'generate':
+    case 'g':
       generate();
       break;
     case 'load':
+    case 'l':
       load(args);
       break;
     default:


### PR DESCRIPTION
You can now type
```
$ coup g
```
and
```
$ coup l
```
for generate and load commands respectively.