### PR TITLE
Generate random seed on game creation

### DIFF
--- a/commands/generate.js
+++ b/commands/generate.js
@@ -8,22 +8,37 @@ const { communications, force, finance, specialInterest } = cards;
 // Functions
 const { log } = console;
 
-const game = [
-  {"c": communications},
-  {"f": force},
-  {"$": finance},
-  {"s": specialInterest},
-  {"s": specialInterest},
-];
+const game = {
+  "Communications": {
+    "count": 1,
+    "colour": cyan,
+    "cards": communications,
+  },
+  "Force": {
+    "count": 1,
+    "colour": yellow,
+    "cards": force,
+  },
+  "Finance": {
+    "count": 1,
+    "colour": red,
+    "cards": finance,
+  },
+  "Special Interest": {
+    "count": 2,
+    "colour": magenta,
+    "cards": specialInterest,
+  },
+};
   
 
 const random = (n) => Math.floor(Math.random() * n); 
 
 const generateGameSeed = () => {
   var s = "";
-  for (const character of game) {
-    for (const symbol in character) {
-      s += `${symbol}${random(character[symbol].length)}`
+  for (const character in game) {
+    for (let i = 0; i < game[character]["count"]; i++) {
+      s += random(game[character]["cards"].length);
     }
   }
   return s;

--- a/commands/generate.js
+++ b/commands/generate.js
@@ -8,6 +8,12 @@ const { communications, force, finance, specialInterest } = cards;
 // Functions
 const { log } = console;
 
+const random = (n) => Math.floor(Math.random() * n); 
+
+const generateGameSeed = () => {
+  return `c${random(communications.length)}f${random(force.length)}$${random(finance.length)}s${random(specialInterest.length)}s${random(specialInterest.length)}`;
+}
+
 const shuffle = (array) => {
   for (let i = array.length - 1; i > 0; i--) {
     const j = Math.floor(Math.random() * (i + 1));
@@ -21,6 +27,8 @@ Array.prototype.sample = function(count = 1) {
 }
 
 module.exports = (args) => {
+  const gameSeed = generateGameSeed();
+  log(gameSeed);
   let deck = [];
 
   deck.push(communications.sample());

--- a/commands/generate.js
+++ b/commands/generate.js
@@ -8,10 +8,25 @@ const { communications, force, finance, specialInterest } = cards;
 // Functions
 const { log } = console;
 
+const game = [
+  {"c": communications},
+  {"f": force},
+  {"$": finance},
+  {"s": specialInterest},
+  {"s": specialInterest},
+];
+  
+
 const random = (n) => Math.floor(Math.random() * n); 
 
 const generateGameSeed = () => {
-  return `c${random(communications.length)}f${random(force.length)}$${random(finance.length)}s${random(specialInterest.length)}s${random(specialInterest.length)}`;
+  var s = "";
+  for (const character of game) {
+    for (const symbol in character) {
+      s += `${symbol}${random(character[symbol].length)}`
+    }
+  }
+  return s;
 }
 
 const shuffle = (array) => {

--- a/commands/generate.js
+++ b/commands/generate.js
@@ -57,8 +57,10 @@ Array.prototype.sample = function(count = 1) {
 }
 
 module.exports = (args) => {
+  // TODO: Not being used yet, leverage when load by seed is complete
   const gameSeed = generateGameSeed();
   log(gameSeed);
+
   let deck = [];
 
   deck.push(communications.sample());


### PR DESCRIPTION
As opposed to shuffling and sampling arrays to generate a deck, we can leverage a game seed. The generation process is fairly simple. For each character in the game object, we iterate through the count of that character. We select a random number as it corresponds to the index in the array. TODO: ensure for Special Interest, no duplication is allowed. It's a fairly quick fix, just waiting till everything is merged, and the generated seed is being used.