### PR TITLE
Added horizontal seperator between cards, for easy distinction

### DIFF
--- a/util/format.js
+++ b/util/format.js
@@ -3,9 +3,11 @@ const { bold } = require('cli-color');
 const game = require('./game');
 
 const cards = ['Communications', 'Force', 'Finance', 'Special Interest', 'Special Interest'];
+const horizontalLine = () => '—'.repeat(process.stdout.columns);
 
 module.exports = (deck) => {
   for (let i = 0; i < cards.length; i++) {
+    console.log(horizontalLine());  
     console.log(game[cards[i]].colour(`${cards[i]}: ${deck[i].name}`));
     console.log(bold('Action: ') + deck[i].action);
     deck[i].counteraction && console.log(bold('Counteraction: ') + deck[i].counteraction);


### PR DESCRIPTION
Add horizontal separation between cards, helps distinguish different cards. Tested, works pretty well, however doesn't scale well upon resize (as pre-rendered size is view's column length, which obviously changes on resize)
![image](https://user-images.githubusercontent.com/8986140/52209062-ac9d5e80-2850-11e9-9c75-dbc1bb36ce3b.png)
