### PR TITLE
Remove redundant use of cards array, use universal game object

### DIFF
--- a/util/format.js
+++ b/util/format.js
@@ -5,7 +5,7 @@ const game = require('./game');
 module.exports = (deck) => {
   let cardIndex = 0;
   for (let card in game) {
-    for (let repetitions = 0; repetitions< game[card].repetitions; repetitions++) {
+    for (let repetitions = 0; repetitions < game[card].count; repetitions++) {
       let i = cardIndex + repetitions;
       console.log(game[card].colour(`${card}: ${deck[i].name}`));
       console.log(bold('Action: ') + deck[i].action);

--- a/util/format.js
+++ b/util/format.js
@@ -2,13 +2,16 @@
 const { bold } = require('cli-color');
 const game = require('./game');
 
-const cards = ['Communications', 'Force', 'Finance', 'Special Interest', 'Special Interest'];
-
 module.exports = (deck) => {
-  for (let i = 0; i < cards.length; i++) {
-    console.log(game[cards[i]].colour(`${cards[i]}: ${deck[i].name}`));
-    console.log(bold('Action: ') + deck[i].action);
-    deck[i].counteraction && console.log(bold('Counteraction: ') + deck[i].counteraction);
+  let cardIndex = 0;
+  for (let card in game) {
+    for (let repetitions = 0; repetitions< game[card].repetitions; repetitions++) {
+      let i = cardIndex + repetitions;
+      console.log(game[card].colour(`${card}: ${deck[i].name}`));
+      console.log(bold('Action: ') + deck[i].action);
+      deck[i].counteraction && console.log(bold('Counteraction: ') + deck[i].counteraction);
+    }
+    cardIndex++;
   }
 };
 


### PR DESCRIPTION
Initially, we were using an array that had the cards listed out. This seemed space redundant, as that information is encapsulated within the game object.

Close #28 